### PR TITLE
chore: add PR template and Firebase workflow permissions

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,84 @@
+## Summary
+
+<!-- What changed and why. Keep this focused on the outcome, not a file-by-file walkthrough. -->
+
+## Type of change
+
+<!-- Check all that apply. -->
+
+- [ ] Bug fix (non-breaking change that fixes an issue)
+- [ ] New feature (non-breaking change that adds functionality)
+- [ ] Breaking change (fix or feature that would cause existing consumers to change behavior)
+- [ ] Documentation only
+- [ ] Refactor / chore (no user-facing behavior change)
+- [ ] Test only
+
+## Areas affected
+
+<!-- Check every area touched by this PR. -->
+
+- [ ] Demo application ([`src/`](src/))
+- [ ] Publishable library ([`projects/ngx-fast-marquee/`](projects/ngx-fast-marquee/))
+- [ ] E2E suite ([`e2e/`](e2e/))
+- [ ] OpenSpec ([`openspec/`](openspec/))
+- [ ] Tooling / CI / dependencies
+- [ ] Documentation ([`README.md`](README.md), [`CONTRIBUTING.md`](CONTRIBUTING.md), [`AGENTS.md`](AGENTS.md))
+
+## Related links
+
+<!-- Optional but helpful for reviewers. -->
+
+- Closes #
+- OpenSpec change: [`openspec/changes/...`](openspec/changes/)
+- Upstream issue / discussion:
+
+## OpenSpec
+
+<!-- For non-trivial changes (features, architecture, breaking changes), use the OpenSpec workflow. -->
+
+- [ ] Not applicable (trivial fix, docs-only, or test-only)
+- [ ] Proposal included in this PR ([`/opsx:propose`](openspec/))
+- [ ] Implemented from an existing OpenSpec change ([`/opsx:apply`](openspec/))
+- [ ] Specs archived / synced ([`/opsx:archive`](openspec/) or sync)
+
+## Test plan
+
+<!-- How did you verify this works? Check off what you ran. -->
+
+- [ ] `npm run lint`
+- [ ] `npm run format`
+- [ ] `ng test`
+- [ ] `pnpm e2e` or `pnpm e2e:local` (if e2e-relevant)
+- [ ] `npm run build:app` (if app-relevant)
+- [ ] `npm run build:lib` (if library-relevant)
+- [ ] Manual verification in the browser (if UI-relevant)
+
+**Steps:**
+
+1.
+2.
+
+## Library / public API
+
+<!-- Complete this section when the library public surface changes. Otherwise write N/A. -->
+
+- [ ] N/A — no library public API changes
+- [ ] Updated [`projects/ngx-fast-marquee/README.md`](projects/ngx-fast-marquee/README.md)
+- [ ] Updated [`projects/ngx-fast-marquee/src/public-api.ts`](projects/ngx-fast-marquee/src/public-api.ts) exports
+- [ ] Semver / version bump considered (if publishing)
+
+## Agent harness upkeep
+
+<!-- Per [AGENTS.md](AGENTS.md): update affected AGENTS.md files in the same change when conventions, structure, or workflows change. -->
+
+- [ ] N/A — no harness-relevant changes
+- [ ] Updated root [`AGENTS.md`](AGENTS.md)
+- [ ] Updated child [`AGENTS.md`](AGENTS.md) ([`src/`](src/AGENTS.md), [`projects/ngx-fast-marquee/`](projects/ngx-fast-marquee/AGENTS.md), [`e2e/`](e2e/AGENTS.md))
+
+## Screenshots / recordings
+
+<!-- Optional. Include for visible UI changes. -->
+
+## Notes for reviewers
+
+<!-- Anything non-obvious: trade-offs, follow-ups, rollout concerns, or areas you want extra eyes on. -->

--- a/.github/workflows/firebase-hosting-pull-request.yml
+++ b/.github/workflows/firebase-hosting-pull-request.yml
@@ -3,6 +3,10 @@
 
 name: Deploy to Firebase Hosting on PR
 'on': pull_request
+permissions:
+  checks: write
+  contents: read
+  pull-requests: write
 jobs:
   build_and_preview:
     if: '${{ github.event.pull_request.head.repo.full_name == github.repository }}'


### PR DESCRIPTION
## Summary

- Add GitHub pull request template
- Add workflow permissions for Firebase PR preview deploy

## Split from #6

Part 1 of 6. Independent — merge anytime.

Made with [Cursor](https://cursor.com)